### PR TITLE
Expand live SF rental search and source branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,20 @@ ranked apartment deck.
 
 Context.dev powers the marketplace-discovery side of the search pipeline:
 
-1. The **Markdown API** renders live Craigslist inventory with listing links
-   intact.
-2. Criblist validates those detail pages and combines them with Mosser's live
-   structured inventory.
-3. The shared pipeline normalizes, deduplicates, filters, and ranks the combined
-   inventory into one consistent deck.
+1. The **HTML API** renders live Craigslist search results through automatic
+   proxy escalation, preserving the exact listing links.
+2. The **Extract API** turns J. Wavro's live San Francisco inventory page into
+   schema-validated listing candidates.
+3. The **Brand API** enriches the landing page with the identity of every
+   provider in the live search network.
+4. Criblist verifies the detail pages and combines them with live Brick +
+   Timber, RentSFNow, and Mosser inventory.
+5. The shared pipeline normalizes, deduplicates, filters, and ranks all five
+   providers into one consistent deck.
 
 The Context.dev API key stays server-side. Source adapters run concurrently,
-short-lived caches make repeat searches fast, and failed sources cannot take
-down the entire search.
+short-lived caches make repeat searches fast, and the first direct feeds open
+the deck without waiting for the deeper Context extraction lane.
 
 ## The product
 
@@ -65,6 +69,8 @@ Open [http://localhost:3000](http://localhost:3000).
 npm run dev
 npm run lint
 npm run typecheck
+npm test
+npm run stress:search
 npm run build
 npm run start
 ```
@@ -81,21 +87,29 @@ app/
 server/search/
 ├── context-client.ts          Context.dev transport
 ├── craigslist.ts              Craigslist discovery and parsing
+├── html.ts                    shared public-page parsing
+├── jwavro.ts                  Context Extract inventory adapter
 ├── mosser.ts                  Structured Mosser inventory adapter
+├── rentbt.ts                  Brick + Timber live inventory adapter
+├── rentsfnow.ts               RentSFNow live inventory adapter
 ├── ranking.ts                 filtering, scoring, and diversity
 ├── schemas.ts                 request and response contracts
 └── service.ts                 search orchestration
 ```
 
-The browser sends one validated preference object to parallel source requests
-at `POST /api/apartment-search`. Mosser results open the deck immediately;
-Context-powered Craigslist results join it in the background. Both adapters
-normalize into one card contract and pass through the same quality gates.
+The browser sends one validated preference object to three parallel lanes at
+`POST /api/apartment-search`: fast direct feeds, Context-powered Craigslist,
+and Context Extract. The first successful lane opens the deck; later matches
+join it without resetting progress. Every adapter normalizes into one card
+contract and passes through the same strict quality gates.
 
 ## Live sources
 
 - Craigslist San Francisco
+- Brick + Timber
+- RentSFNow
 - Mosser Living
+- J. Wavro Associates
 
 Each adapter starts from the provider's current-availability page instead of a
 stale search index.
@@ -104,7 +118,7 @@ stale search index.
 
 | Variable | Required | Purpose |
 | --- | --- | --- |
-| `CONTEXT_DEV_API_KEY` | yes | Live Craigslist discovery through Context.dev |
+| `CONTEXT_DEV_API_KEY` | yes | Context.dev HTML, Extract, and Brand API access |
 | `NEXT_PUBLIC_SITE_URL` | no | Canonical URL for social metadata |
 
 Do not commit `.env.local`.

--- a/app/_components/criblist/home-page.tsx
+++ b/app/_components/criblist/home-page.tsx
@@ -134,7 +134,9 @@ export function HomePage() {
     setCurrentIndex(0);
     setHistory([]);
 
-    const requestSource = async (source: "independent" | "craigslist") => {
+    const requestSource = async (
+      source: "fast" | "craigslist" | "extract",
+    ) => {
       const response = await fetch(`/api/apartment-search?source=${source}`, {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -148,22 +150,29 @@ export function HomePage() {
       return result.apartments ?? [];
     };
 
-    const independentRequest = requestSource("independent");
-    const craigslistRequest = requestSource("craigslist");
-
     try {
-      const independent = await independentRequest.catch(() => []);
+      const laneResults = await Promise.all(
+        (["fast", "craigslist", "extract"] as const).map(async (source) => {
+          try {
+            const result = await requestSource(source);
+            if (searchSequence.current === sequence && result.length > 0) {
+              setApartments((current) =>
+                dedupeApartments([...current, ...result]),
+              );
+              setStage("deck");
+            }
+            return result;
+          } catch {
+            return [];
+          }
+        }),
+      );
       if (searchSequence.current !== sequence) return;
-      if (independent.length > 0) {
-        setApartments(independent);
-        setStage("deck");
+      const combined = dedupeApartments(laneResults.flat());
+      if (combined.length === 0) {
+        setApartments([]);
+        setStage("done");
       }
-
-      const craigslist = await craigslistRequest.catch(() => []);
-      if (searchSequence.current !== sequence) return;
-      const combined = dedupeApartments([...independent, ...craigslist]);
-      setApartments(combined);
-      setStage(combined.length > 0 ? "deck" : "done");
     } catch (searchError) {
       if (searchSequence.current !== sequence) return;
       setError(

--- a/app/_components/criblist/provider-sources.tsx
+++ b/app/_components/criblist/provider-sources.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { motion, useReducedMotion } from "motion/react";
+import { FadeImage } from "@/_components/ui/fade-image";
+import {
+  fallbackProviderBrands,
+  LISTING_PROVIDERS,
+  type ProviderBrand,
+} from "../../../shared/providers";
+
+const SOURCE_ACCENTS: Record<string, string> = {
+  "craigslist.org": "#7d35a5",
+  "rentbt.com": "#b57d66",
+  "rentsfnow.com": "#d1492e",
+  "mosserliving.com": "#1796c7",
+  "jwavro.com": "#3d496b",
+};
+
+const PROVIDER_BRANDS_ENDPOINT = "/api/provider-brands?v=2";
+
+export function ProviderSources() {
+  const [providers, setProviders] = useState(fallbackProviderBrands);
+  const reduceMotion = useReducedMotion();
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch(PROVIDER_BRANDS_ENDPOINT, {
+      signal: controller.signal,
+      cache: "no-cache",
+    })
+      .then(async (response) => {
+        if (!response.ok) throw new Error("provider brands unavailable");
+        return response.json() as Promise<{ providers?: ProviderBrand[] }>;
+      })
+      .then((result) => {
+        if (result.providers?.length === LISTING_PROVIDERS.length) {
+          setProviders(result.providers);
+        }
+      })
+      .catch(() => undefined);
+    return () => controller.abort();
+  }, []);
+
+  const sourceCount = providers.length;
+
+  return (
+    <motion.section
+      aria-label="live apartment sources"
+      initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, delay: 0.18, ease: [0.23, 1, 0.32, 1] }}
+      className="mt-6 flex flex-col items-center gap-3"
+    >
+      <div className="group flex items-center">
+        {providers.map((provider, index) => {
+          const accent =
+            provider.color ??
+            SOURCE_ACCENTS[provider.domain] ??
+            SOURCE_ACCENTS["jwavro.com"];
+          return (
+            <motion.a
+              key={provider.domain}
+              href={provider.url}
+              target="_blank"
+              rel="noreferrer"
+              title={`browse ${provider.title}`}
+              initial={reduceMotion ? false : { opacity: 0, scale: 0.6 }}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{
+                duration: 0.4,
+                delay: reduceMotion ? 0 : 0.22 + index * 0.07,
+                ease: [0.34, 1.56, 0.64, 1],
+              }}
+              style={{ zIndex: sourceCount - index }}
+              className="group/coin relative -ml-2.5 rounded-full outline-none transition-[margin] duration-300 ease-out first:ml-0 hover:z-20 focus-visible:z-20 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background group-hover:ml-1 group-hover:first:ml-0"
+            >
+              <span
+                className="grid size-10 place-items-center overflow-hidden rounded-full border-2 border-background bg-card shadow-swatch transition duration-300 ease-out group-hover/coin:-translate-y-1.5 group-hover/coin:scale-110 group-hover/coin:shadow-[0_10px_20px_-6px_rgba(63,48,38,0.3)]"
+                style={{ backgroundColor: `${accent}14` }}
+              >
+                {provider.logoUrl ? (
+                  <FadeImage
+                    src={provider.logoUrl}
+                    alt=""
+                    referrerPolicy="no-referrer"
+                    className="size-[22px] object-contain"
+                  />
+                ) : (
+                  <span
+                    className="text-[14px] font-bold uppercase leading-none"
+                    style={{ color: accent }}
+                  >
+                    {provider.label.slice(0, 1)}
+                  </span>
+                )}
+              </span>
+              <span className="pointer-events-none absolute -top-7 left-1/2 -translate-x-1/2 -translate-y-0.5 whitespace-nowrap rounded-full bg-foreground px-2 py-0.5 text-[9px] font-medium text-card opacity-0 shadow-card-1 transition-all duration-200 group-hover/coin:-translate-y-0 group-hover/coin:opacity-100">
+                {provider.label}
+              </span>
+            </motion.a>
+          );
+        })}
+      </div>
+
+      <p className="inline-flex items-center gap-1.5 text-[11px] font-medium text-secondary">
+        <span>
+          {sourceCount} live sf sources ·{" "}
+          <a
+            href="https://context.dev"
+            target="_blank"
+            rel="noreferrer"
+            className="underline decoration-border underline-offset-2 transition-colors hover:text-foreground hover:decoration-foreground"
+          >
+            via context.dev
+          </a>
+        </span>
+      </p>
+    </motion.section>
+  );
+}

--- a/app/_components/criblist/search.tsx
+++ b/app/_components/criblist/search.tsx
@@ -18,6 +18,7 @@ import {
   type LaundryPreference,
   type Preferences,
 } from "./model";
+import { ProviderSources } from "./provider-sources";
 
 export function SearchSetup({
   preferences,
@@ -58,6 +59,7 @@ export function SearchSetup({
           tell criblist what you want. it pulls listings that are live right
           now and hands you a deck to swipe through.
         </p>
+        <ProviderSources />
       </div>
 
       <PanelCard radius={22} className="p-4 sm:p-5">

--- a/app/api/apartment-search/route.ts
+++ b/app/api/apartment-search/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from "next/server";
-import { searchApartments } from "../../../server/search/service";
+import {
+  searchApartments,
+  type SearchSource,
+} from "../../../server/search/service";
 import { PreferencesSchema } from "../../../server/search/schemas";
 
 export const maxDuration = 300;
@@ -7,10 +10,7 @@ export const maxDuration = 300;
 export async function POST(request: Request) {
   try {
     const sourceParameter = new URL(request.url).searchParams.get("source");
-    const source =
-      sourceParameter === "independent" || sourceParameter === "craigslist"
-        ? sourceParameter
-        : "all";
+    const source = isSearchSource(sourceParameter) ? sourceParameter : "all";
     const preferences = PreferencesSchema.parse(await request.json());
     if (preferences.budgetMin > preferences.budgetMax) {
       return NextResponse.json(
@@ -31,4 +31,14 @@ export async function POST(request: Request) {
     const message = error instanceof Error ? error.message : String(error);
     return NextResponse.json({ error: message }, { status: 500 });
   }
+}
+
+function isSearchSource(value: string | null): value is SearchSource {
+  return (
+    value === "all" ||
+    value === "fast" ||
+    value === "independent" ||
+    value === "craigslist" ||
+    value === "extract"
+  );
 }

--- a/app/api/provider-brands/route.ts
+++ b/app/api/provider-brands/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { retrieveProviderBrands } from "../../../server/brand/providers";
+import { fallbackProviderBrands } from "../../../shared/providers";
+
+export const maxDuration = 60;
+
+export async function GET() {
+  const apiKey = process.env.CONTEXT_DEV_API_KEY;
+  const providers = apiKey
+    ? await retrieveProviderBrands(apiKey)
+    : fallbackProviderBrands();
+
+  return NextResponse.json(
+    {
+      providers,
+      enrichedBy: apiKey ? "context.dev brand api" : null,
+    },
+    {
+      headers: {
+        "Cache-Control":
+          "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800",
+      },
+    },
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "eslint": "^9.39.0",
         "eslint-config-next": "^16.2.6",
         "tailwindcss": "^4.3.0",
+        "tsx": "^4.23.1",
         "typescript": "^6.0.3"
       },
       "engines": {
@@ -333,6 +334,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3109,6 +3552,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3807,6 +4292,21 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -6405,6 +6905,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test tests/*.test.ts",
+    "stress:search": "node scripts/stress-search.mjs"
   },
   "keywords": [
     "apartments",
@@ -43,6 +45,7 @@
     "eslint": "^9.39.0",
     "eslint-config-next": "^16.2.6",
     "tailwindcss": "^4.3.0",
+    "tsx": "^4.23.1",
     "typescript": "^6.0.3"
   }
 }

--- a/scripts/stress-search.mjs
+++ b/scripts/stress-search.mjs
@@ -1,0 +1,170 @@
+const baseUrl = process.env.CRIBLIST_BASE_URL ?? "http://localhost:3000";
+const lanes = ["fast", "craigslist", "extract"];
+const profiles = [
+  {
+    name: "studio-value",
+    budgetMin: 1_500,
+    budgetMax: 3_000,
+    bedrooms: "studio",
+    bathroomsMin: 1,
+    neighborhoods: [],
+    moveIn: "30 days",
+    laundry: "any",
+    dishwasher: false,
+    pets: false,
+    minSquareFeet: 0,
+  },
+  {
+    name: "one-bed-default",
+    budgetMin: 1_800,
+    budgetMax: 3_500,
+    bedrooms: "1",
+    bathroomsMin: 1,
+    neighborhoods: [],
+    moveIn: "30 days",
+    laundry: "any",
+    dishwasher: false,
+    pets: false,
+    minSquareFeet: 0,
+  },
+  {
+    name: "one-bed-market",
+    budgetMin: 2_500,
+    budgetMax: 4_500,
+    bedrooms: "1",
+    bathroomsMin: 1,
+    neighborhoods: [],
+    moveIn: "30 days",
+    laundry: "any",
+    dishwasher: false,
+    pets: false,
+    minSquareFeet: 0,
+  },
+  {
+    name: "two-bed",
+    budgetMin: 3_000,
+    budgetMax: 6_000,
+    bedrooms: "2",
+    bathroomsMin: 1,
+    neighborhoods: [],
+    moveIn: "60 days",
+    laundry: "any",
+    dishwasher: false,
+    pets: false,
+    minSquareFeet: 0,
+  },
+  {
+    name: "three-plus",
+    budgetMin: 4_000,
+    budgetMax: 10_000,
+    bedrooms: "3+",
+    bathroomsMin: 1,
+    neighborhoods: [],
+    moveIn: "flexible",
+    laundry: "any",
+    dishwasher: false,
+    pets: false,
+    minSquareFeet: 0,
+  },
+  {
+    name: "strict-one-bed",
+    budgetMin: 2_500,
+    budgetMax: 4_500,
+    bedrooms: "1",
+    bathroomsMin: 1,
+    neighborhoods: ["Mission", "Hayes Valley", "Noe Valley"],
+    moveIn: "30 days",
+    laundry: "in-unit",
+    dishwasher: true,
+    pets: true,
+    minSquareFeet: 500,
+  },
+];
+
+const results = await Promise.all(
+  profiles.flatMap((profile) =>
+    lanes.map((lane) => runLane(profile, lane)),
+  ),
+);
+
+const summaries = profiles.map((profile) => {
+  const profileResults = results.filter(
+    (result) => result.profile === profile.name,
+  );
+  const apartments = dedupe(
+    profileResults.flatMap((result) => result.apartments),
+  );
+  const successfulDurations = profileResults
+    .filter((result) => result.apartments.length > 0)
+    .map((result) => result.durationMs);
+  return {
+    profile: profile.name,
+    total: apartments.length,
+    providers: Object.keys(providerCounts(apartments)).length,
+    mix: JSON.stringify(providerCounts(apartments)),
+    firstMs:
+      successfulDurations.length > 0
+        ? Math.min(...successfulDurations)
+        : null,
+    allMs: Math.max(...profileResults.map((result) => result.durationMs)),
+    errors: profileResults.filter((result) => result.error).length,
+  };
+});
+
+console.table(summaries);
+
+if (summaries.some((summary) => summary.errors > 0)) process.exitCode = 1;
+
+async function runLane(profile, lane) {
+  const startedAt = Date.now();
+  try {
+    const response = await fetch(
+      `${baseUrl}/api/apartment-search?source=${lane}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(withoutName(profile)),
+        signal: AbortSignal.timeout(90_000),
+      },
+    );
+    const result = await response.json();
+    if (!response.ok) throw new Error(result.error ?? `HTTP ${response.status}`);
+    return {
+      profile: profile.name,
+      lane,
+      durationMs: Date.now() - startedAt,
+      apartments: result.apartments ?? [],
+      error: null,
+    };
+  } catch (error) {
+    return {
+      profile: profile.name,
+      lane,
+      durationMs: Date.now() - startedAt,
+      apartments: [],
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function withoutName(profile) {
+  const { name, ...preferences } = profile;
+  return preferences;
+}
+
+function dedupe(apartments) {
+  return [
+    ...new Map(apartments.map((apartment) => [apartment.url, apartment])).values(),
+  ];
+}
+
+function providerCounts(apartments) {
+  return apartments.reduce(
+    (counts, apartment) => ({
+      ...counts,
+      [apartment.provider ?? "unknown"]:
+        (counts[apartment.provider ?? "unknown"] ?? 0) + 1,
+    }),
+    {},
+  );
+}

--- a/server/brand/providers.ts
+++ b/server/brand/providers.ts
@@ -1,0 +1,202 @@
+import * as z from "zod/v4";
+import {
+  LISTING_PROVIDERS,
+  type ProviderBrand,
+} from "../../shared/providers";
+import { requestContext } from "../search/context-client";
+
+const PROVIDER_CACHE_VERSION = 2;
+
+const BrandResponseSchema = z
+  .object({
+    brand: z
+      .object({
+        title: z.string().optional(),
+        colors: z
+          .array(
+            z
+              .object({
+                hex: z.string(),
+              })
+              .passthrough(),
+          )
+          .optional(),
+        logos: z
+          .array(
+            z
+              .object({
+                url: z.string(),
+                type: z.string().optional(),
+                mode: z.string().optional(),
+                resolution: z
+                  .object({
+                    width: z.number().optional(),
+                    height: z.number().optional(),
+                    aspect_ratio: z.number().optional(),
+                  })
+                  .optional(),
+              })
+              .passthrough(),
+          )
+          .optional(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+const globalProviderBrands = globalThis as typeof globalThis & {
+  criblistProviderBrands?: {
+    version: number;
+    expiresAt: number;
+    providers: ProviderBrand[];
+  };
+  criblistProviderBrandsRequest?: Promise<ProviderBrand[]>;
+};
+
+export async function retrieveProviderBrands(apiKey: string) {
+  const cached = globalProviderBrands.criblistProviderBrands;
+  if (
+    cached &&
+    cached.version === PROVIDER_CACHE_VERSION &&
+    cached.expiresAt > Date.now()
+  ) {
+    return cached.providers;
+  }
+
+  const activeRequest = globalProviderBrands.criblistProviderBrandsRequest;
+  if (activeRequest) return activeRequest;
+
+  const request = Promise.all(
+    LISTING_PROVIDERS.map((provider) =>
+      retrieveProviderBrand(provider, apiKey),
+    ),
+  );
+  globalProviderBrands.criblistProviderBrandsRequest = request;
+  try {
+    const providers = await request;
+    globalProviderBrands.criblistProviderBrands = {
+      version: PROVIDER_CACHE_VERSION,
+      expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+      providers,
+    };
+    return providers;
+  } finally {
+    if (globalProviderBrands.criblistProviderBrandsRequest === request) {
+      delete globalProviderBrands.criblistProviderBrandsRequest;
+    }
+  }
+}
+
+async function retrieveProviderBrand(
+  provider: (typeof LISTING_PROVIDERS)[number],
+  apiKey: string,
+): Promise<ProviderBrand> {
+  try {
+    const primaryBrand = await retrieveBrand(
+      {
+        type: "by_domain",
+        domain: provider.domain,
+      },
+      apiKey,
+    );
+    const fallbackLookup =
+      "fallbackLookup" in provider ? provider.fallbackLookup : null;
+    const fallbackBrand =
+      (primaryBrand.logos?.length ?? 0) === 0 && fallbackLookup
+        ? await retrieveBrand(fallbackLookup, apiKey)
+        : null;
+    const brand = fallbackBrand ?? primaryBrand;
+    return {
+      domain: provider.domain,
+      label: provider.label,
+      url: provider.url,
+      title: brand.title?.trim() || provider.label,
+      logoUrl: selectPreferredBrandLogo(brand.logos ?? []),
+      color: preferredColor(brand.colors ?? []),
+    };
+  } catch {
+    return {
+      domain: provider.domain,
+      label: provider.label,
+      url: provider.url,
+      title: provider.label,
+      logoUrl: null,
+      color: null,
+    };
+  }
+}
+
+async function retrieveBrand(
+  lookup:
+    | { type: "by_domain"; domain: string }
+    | { type: "by_name"; name: string },
+  apiKey: string,
+) {
+  const response = await requestContext("/brand/retrieve", apiKey, {
+    init: {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...lookup,
+        force_language: "english",
+        maxSpeed: true,
+        maxAgeMs: 7_776_000_000,
+        timeoutMS: 20_000,
+        tags: ["criblist", "landing-page", "provider"],
+      }),
+    },
+    timeoutMs: 23_000,
+    maxAttempts: 2,
+  });
+  return BrandResponseSchema.parse(response).brand;
+}
+
+export function selectPreferredBrandLogo(
+  logos: Array<{
+    url: string;
+    type?: string;
+    mode?: string;
+    resolution?: {
+      width?: number;
+      height?: number;
+      aspect_ratio?: number;
+    };
+  }>,
+) {
+  return (
+    [...logos]
+      .filter((logo) => /^https?:\/\//i.test(logo.url))
+      .sort((first, second) => logoScore(second) - logoScore(first))[0]
+      ?.url ?? null
+  );
+}
+
+function logoScore(logo: {
+  type?: string;
+  mode?: string;
+  resolution?: {
+    width?: number;
+    height?: number;
+    aspect_ratio?: number;
+  };
+}) {
+  const width = logo.resolution?.width ?? 0;
+  const height = logo.resolution?.height ?? 0;
+  const ratio =
+    logo.resolution?.aspect_ratio ??
+    (width > 0 && height > 0 ? width / height : 1);
+  const typeScore =
+    logo.type === "icon" ? 3_000_000 : logo.type === "logo" ? 1_000_000 : 0;
+  const shapeScore = Math.max(0, 1_000_000 - Math.abs(1 - ratio) * 600_000);
+  const resolutionScore = Math.min(width * height, 500_000);
+  const modeScore = logo.mode === "light" ? 100_000 : 0;
+  return typeScore + shapeScore + resolutionScore + modeScore;
+}
+
+function preferredColor(colors: Array<{ hex: string }>) {
+  return (
+    colors
+      .map((color) => color.hex)
+      .find((color) => /^#[0-9a-f]{6}$/i.test(color)) ?? null
+  );
+}

--- a/server/search/context-client.ts
+++ b/server/search/context-client.ts
@@ -108,29 +108,6 @@ function releaseContextSlot() {
   globalContextQueue.criblistContextWaiters?.shift()?.();
 }
 
-export function markdownPath(
-  url: string,
-  options: {
-    maxAgeMs: number;
-    waitForMs: number;
-    timeoutMs: number;
-    includeImages?: boolean;
-  },
-) {
-  const params = new URLSearchParams({
-    url,
-    includeLinks: "true",
-    includeImages: String(options.includeImages ?? true),
-    useMainContentOnly: "true",
-    shortenBase64Images: "true",
-    maxAgeMs: String(options.maxAgeMs),
-    waitForMs: String(options.waitForMs),
-    timeoutMS: String(options.timeoutMs),
-    country: "us",
-  });
-  return `/web/scrape/markdown?${params.toString()}`;
-}
-
 export function htmlPath(
   url: string,
   options: {

--- a/server/search/craigslist.ts
+++ b/server/search/craigslist.ts
@@ -1,14 +1,22 @@
-import { markdownPath, requestContext } from "./context-client";
+import { htmlPath, requestContext } from "./context-client";
+import {
+  decodeHtml,
+  fetchPublicHtml,
+  formatPostalAddress,
+  jsonLdFromHtml,
+  metaContent,
+  textFromHtml,
+} from "./html";
 import {
   cleanImageUrls,
   createApartmentCard,
   inferNeighborhood,
 } from "./ranking";
-import { MarkdownResponseSchema } from "./schemas";
+import { HtmlResponseSchema } from "./schemas";
 import type {
   ApartmentCard,
   ExtractedApartment,
-  MarkdownSnapshot,
+  ListingSnapshot,
   Preferences,
 } from "./schemas";
 
@@ -47,7 +55,7 @@ export async function discoverCraigslistListings(
   apiKey: string,
 ) {
   const cacheKey = JSON.stringify({
-    version: 4,
+    version: 6,
     budgetMin: preferences.budgetMin,
     budgetMax: preferences.budgetMax,
     bedrooms: preferences.bedrooms,
@@ -70,7 +78,7 @@ export async function discoverCraigslistListings(
             candidate.name,
           ),
       )
-      .slice(0, 6)
+      .slice(0, 10)
       .map((candidate) => candidate.url);
     const cards = await Promise.all(
       urls.map((url) => scrapeListing(url, preferences)),
@@ -99,16 +107,16 @@ async function discoverSearchCandidates(
   if (cached && cached.expiresAt > Date.now()) return cached.candidates;
 
   const response = await requestContext(
-    markdownPath(searchUrl, {
+    htmlPath(searchUrl, {
       maxAgeMs: 2 * 60 * 1000,
-      waitForMs: 300,
-      timeoutMs: 12_000,
+      waitForMs: 0,
+      timeoutMs: 25_000,
     }),
     apiKey,
-    { timeoutMs: 14_000, maxAttempts: 1 },
+    { timeoutMs: 28_000, maxAttempts: 1 },
   );
-  const snapshot = MarkdownResponseSchema.parse(response);
-  const candidates = extractSearchCandidates(snapshot.markdown);
+  const snapshot = HtmlResponseSchema.parse(response);
+  const candidates = extractCraigslistSearchCandidates(snapshot.html);
   craigslistSearchCache.set(searchUrl, {
     expiresAt: Date.now() + 2 * 60 * 1000,
     candidates,
@@ -117,8 +125,13 @@ async function discoverSearchCandidates(
 }
 
 function buildSearchUrl(preferences: Preferences) {
-  const searchUrl = new URL("https://sfbay.craigslist.org/search/sfc/apa");
+  const searchUrl = new URL(
+    "https://www.craigslist.org/search/subarea/sfc",
+  );
+  searchUrl.searchParams.set("cat", "apa");
   searchUrl.searchParams.set("availabilityMode", "0");
+  searchUrl.searchParams.set("min_price", String(preferences.budgetMin));
+  searchUrl.searchParams.set("max_price", String(preferences.budgetMax));
   Object.entries(bedroomParams(preferences.bedrooms)).forEach(([key, value]) =>
     searchUrl.searchParams.set(key, value),
   );
@@ -127,14 +140,16 @@ function buildSearchUrl(preferences: Preferences) {
 
 function bedroomParams(bedrooms: Preferences["bedrooms"]) {
   if (bedrooms === "studio") {
-    return { min_bedrooms: "0", max_bedrooms: "0" };
+    return { hub: "studio-apartment" };
   }
+  if (bedrooms === "1") return { hub: "one-bedroom-apartment" };
+  if (bedrooms === "2") return { hub: "two-bedroom-apartment" };
   if (bedrooms === "3+") return { min_bedrooms: "3" };
-  return { min_bedrooms: bedrooms, max_bedrooms: bedrooms };
+  return {};
 }
 
-function extractSearchCandidates(markdown: string) {
-  const normalized = markdown.replaceAll("\\/", "/").replaceAll("&amp;", "&");
+export function extractCraigslistSearchCandidates(html: string) {
+  const normalized = html.replaceAll("\\/", "/").replaceAll("&amp;", "&");
   const candidates = [
     ...normalized.matchAll(
       /<li class="cl-static-search-result"[\s\S]*?<\/li>/gi,
@@ -184,22 +199,14 @@ async function scrapeListing(
 
 async function fetchListingSnapshot(
   url: string,
-): Promise<MarkdownSnapshot> {
-  const response = await fetch(url, {
-    headers: {
-      Accept: "text/html,application/xhtml+xml",
-      "User-Agent":
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/131 Safari/537.36",
-    },
-    signal: AbortSignal.timeout(4_000),
-  });
-  if (!response.ok) {
-    throw new Error(`Craigslist returned ${response.status}.`);
-  }
-  return snapshotFromHtml(url, await response.text());
+): Promise<ListingSnapshot> {
+  return snapshotFromHtml(url, await fetchPublicHtml(url, 5_000));
 }
 
-function snapshotFromHtml(url: string, html: string): MarkdownSnapshot {
+export function snapshotFromHtml(
+  url: string,
+  html: string,
+): ListingSnapshot {
   const pageTitle = decodeHtml(
     html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1] ?? "",
   ).trim();
@@ -235,14 +242,7 @@ function snapshotFromHtml(url: string, html: string): MarkdownSnapshot {
       ) ?? [],
     ),
   ];
-  const body = decodeHtml(
-    html
-      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
-      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
-      .replace(/<[^>]+>/g, "\n"),
-  )
-    .replace(/[ \t]+/g, " ")
-    .replace(/\n{3,}/g, "\n\n");
+  const body = textFromHtml(html);
   const jsonLd = jsonLdFromHtml(html);
   const markdown = `# ${postingTitle || pageTitle}\n\n${body}\n\n${images.join("\n")}`;
   return {
@@ -260,53 +260,8 @@ function snapshotFromHtml(url: string, html: string): MarkdownSnapshot {
   };
 }
 
-function metaContent(html: string, key: string) {
-  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return (
-    html.match(
-      new RegExp(
-        `<meta[^>]+(?:name|property)=["']${escapedKey}["'][^>]+content=["']([^"']*)["']`,
-        "i",
-      ),
-    )?.[1] ??
-    html.match(
-      new RegExp(
-        `<meta[^>]+content=["']([^"']*)["'][^>]+(?:name|property)=["']${escapedKey}["']`,
-        "i",
-      ),
-    )?.[1]
-  );
-}
-
-function jsonLdFromHtml(html: string) {
-  return [...html.matchAll(
-    /<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi,
-  )].flatMap((match) => {
-    try {
-      const value = JSON.parse(match[1]) as
-        | Record<string, unknown>
-        | Record<string, unknown>[];
-      return Array.isArray(value) ? value : [value];
-    } catch {
-      return [];
-    }
-  });
-}
-
-function decodeHtml(value: string) {
-  return value
-    .replaceAll("&amp;", "&")
-    .replaceAll("&quot;", "\"")
-    .replaceAll("&#39;", "'")
-    .replaceAll("&lt;", "<")
-    .replaceAll("&gt;", ">")
-    .replace(/&#(\d+);/g, (_, code: string) =>
-      String.fromCodePoint(Number(code)),
-    );
-}
-
-function cardFromSnapshot(
-  snapshot: MarkdownSnapshot,
+export function cardFromSnapshot(
+  snapshot: ListingSnapshot,
   preferences: Preferences,
 ) {
   const heading = snapshot.markdown.match(/^# (.+)$/m)?.[1]?.trim();
@@ -332,7 +287,18 @@ function cardFromSnapshot(
     .replace(/^\d+br\s*-\s*/i, "")
     .replace(/^[\d,]+\s*ft\s*2\s*-\s*/i, "")
     .trim();
-  const name = titleWithoutPrice.replace(/\s+\([^()]*(?:\)|$)/, "").trim();
+  const rawName = titleWithoutPrice
+    .replace(/\s+\([^()]*(?:\)|$)/, "")
+    .trim();
+  const advertisedPrice = Number(
+    rawName.match(/\$([\d,]+)/)?.[1]?.replaceAll(",", "") ?? NaN,
+  );
+  const hasMismatchedHeadlinePrice =
+    Number.isFinite(advertisedPrice) && advertisedPrice !== price;
+  const name = (hasMismatchedHeadlinePrice
+    ? rawName.replace(/\$[\d,]+/g, "").replace(/\s{2,}/g, " ")
+    : rawName
+  ).trim();
   if (
     /\b\d+\s*-\s*\d+\s*(?:br|beds?|bedrooms?)\b/i.test(name) ||
     /\b(room for rent|private room|shared room|inlaw room)\b/i.test(name)
@@ -359,14 +325,15 @@ function cardFromSnapshot(
     return null;
   }
 
-  const listingData = snapshot.metadata.jsonLd?.find(
-    (entry) => entry["@type"] === "Apartment",
+  const listingData = snapshot.metadata.jsonLd?.find((entry) =>
+    ["Apartment", "House", "Residence", "SingleFamilyResidence"].includes(
+      String(entry["@type"]),
+    ),
   );
   const addressData = listingData?.address;
   const address =
-    typeof addressData === "object" && addressData !== null
-      ? formatPostalAddress(addressData as Record<string, unknown>)
-      : (snapshot.markdown.match(/^## (.+)$/m)?.[1] ?? null);
+    formatPostalAddress(addressData) ??
+    (snapshot.markdown.match(/^## (.+)$/m)?.[1] ?? null);
   if (!address || !/\bsan francisco\b/i.test(address)) return null;
   const bathroomsValue = listingData?.numberOfBathroomsTotal;
   const bathrooms =
@@ -402,6 +369,11 @@ function cardFromSnapshot(
     amenities: inferAmenities(snapshot.markdown, laundry),
     description: sourceDescription || name,
     caveats: [
+      ...(hasMismatchedHeadlinePrice
+        ? [
+            `The headline mentioned a different rent; the listing currently shows $${price.toLocaleString()}.`,
+          ]
+        : []),
       "Craigslist listing: verify the poster and tour before paying.",
     ],
   };
@@ -468,18 +440,4 @@ function hasScamSignals(text: string) {
   return /(must\s+text\s+me\s+your\s+email|kindly\s+(?:text|send|reply)|wire\s+(?:the\s+)?money|western\s+union|pay\s+before\s+(?:viewing|touring)|i(?:'m| am)\s+(?:currently\s+)?out\s+of\s+(?:town|country)|crypto(?:currency)?\s+payment)/i.test(
     text,
   );
-}
-
-function formatPostalAddress(address: Record<string, unknown>) {
-  return [
-    address.streetAddress,
-    address.addressLocality,
-    address.addressRegion,
-    address.postalCode,
-  ]
-    .filter(
-      (value): value is string =>
-        typeof value === "string" && value.length > 0,
-    )
-    .join(", ");
 }

--- a/server/search/html.ts
+++ b/server/search/html.ts
@@ -1,0 +1,137 @@
+const HTML_HEADERS = {
+  Accept: "text/html,application/xhtml+xml",
+  "User-Agent":
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/131 Safari/537.36",
+};
+
+const globalHtmlCache = globalThis as typeof globalThis & {
+  criblistHtmlCache?: Map<string, { expiresAt: number; html: string }>;
+  criblistHtmlRequests?: Map<string, Promise<string>>;
+};
+const htmlCache = globalHtmlCache.criblistHtmlCache ?? new Map();
+const htmlRequests = globalHtmlCache.criblistHtmlRequests ?? new Map();
+globalHtmlCache.criblistHtmlCache = htmlCache;
+globalHtmlCache.criblistHtmlRequests = htmlRequests;
+
+export async function fetchPublicHtml(
+  url: string,
+  timeoutMs = 7_000,
+  maxAgeMs = 60_000,
+) {
+  const cached = htmlCache.get(url);
+  if (cached && cached.expiresAt > Date.now()) return cached.html;
+
+  const activeRequest = htmlRequests.get(url);
+  if (activeRequest) return activeRequest;
+
+  const request = fetch(url, {
+    headers: HTML_HEADERS,
+    signal: AbortSignal.timeout(timeoutMs),
+  }).then(async (response) => {
+    if (!response.ok) {
+      throw new Error(`${new URL(url).hostname} returned ${response.status}.`);
+    }
+    const html = await response.text();
+    htmlCache.set(url, { expiresAt: Date.now() + maxAgeMs, html });
+    trimHtmlCache();
+    return html;
+  });
+  htmlRequests.set(url, request);
+  try {
+    return await request;
+  } finally {
+    if (htmlRequests.get(url) === request) htmlRequests.delete(url);
+  }
+}
+
+export function jsonLdFromHtml(html: string) {
+  return [
+    ...html.matchAll(
+      /<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi,
+    ),
+  ].flatMap((match) => {
+    try {
+      const value = JSON.parse(match[1]) as unknown;
+      return flattenJsonLd(value);
+    } catch {
+      return [];
+    }
+  });
+}
+
+export function metaContent(html: string, key: string) {
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return (
+    html.match(
+      new RegExp(
+        `<meta[^>]+(?:name|property)=["']${escapedKey}["'][^>]+content=["']([^"']*)["']`,
+        "i",
+      ),
+    )?.[1] ??
+    html.match(
+      new RegExp(
+        `<meta[^>]+content=["']([^"']*)["'][^>]+(?:name|property)=["']${escapedKey}["']`,
+        "i",
+      ),
+    )?.[1]
+  );
+}
+
+export function decodeHtml(value: string) {
+  return value
+    .replaceAll("&amp;", "&")
+    .replaceAll("&quot;", "\"")
+    .replaceAll("&#039;", "'")
+    .replaceAll("&#39;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replace(/&#(\d+);/g, (_, code: string) =>
+      String.fromCodePoint(Number(code)),
+    );
+}
+
+export function textFromHtml(html: string) {
+  return decodeHtml(
+    html
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
+      .replace(/<[^>]+>/g, "\n"),
+  )
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n");
+}
+
+export function formatPostalAddress(value: unknown) {
+  if (!isRecord(value)) return null;
+  const address = [
+    value.streetAddress,
+    value.addressLocality,
+    value.addressRegion,
+    value.postalCode,
+  ]
+    .filter(
+      (part): part is string =>
+        typeof part === "string" && part.trim().length > 0,
+    )
+    .join(", ");
+  return address || null;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function flattenJsonLd(value: unknown): Record<string, unknown>[] {
+  if (Array.isArray(value)) return value.flatMap(flattenJsonLd);
+  if (!isRecord(value)) return [];
+  const graph = Array.isArray(value["@graph"])
+    ? value["@graph"].flatMap(flattenJsonLd)
+    : [];
+  return [value, ...graph];
+}
+
+function trimHtmlCache() {
+  if (htmlCache.size <= 100) return;
+  const oldestKey = htmlCache.keys().next().value;
+  if (typeof oldestKey === "string") htmlCache.delete(oldestKey);
+}

--- a/server/search/jwavro.ts
+++ b/server/search/jwavro.ts
@@ -1,0 +1,306 @@
+import { requestContext } from "./context-client";
+import {
+  fetchPublicHtml,
+  formatPostalAddress,
+  isRecord,
+  jsonLdFromHtml,
+  textFromHtml,
+} from "./html";
+import {
+  cleanImageUrls,
+  createApartmentCard,
+  matchesBedrooms,
+} from "./ranking";
+import { ExtractListingsResponseSchema } from "./schemas";
+import type {
+  ApartmentCard,
+  ContextListing,
+  Preferences,
+} from "./schemas";
+
+const INVENTORY_URL = "https://www.jwavro.com/rental_list.php?hood=sfc";
+
+const globalCache = globalThis as typeof globalThis & {
+  criblistJwavroCandidateCache?: {
+    expiresAt: number;
+    candidates: ContextListing[];
+  };
+  criblistJwavroCandidateRequest?: Promise<ContextListing[]>;
+  criblistJwavroDeckCache?: Map<
+    string,
+    { expiresAt: number; apartments: ApartmentCard[] }
+  >;
+};
+const deckCache = globalCache.criblistJwavroDeckCache ?? new Map();
+globalCache.criblistJwavroDeckCache = deckCache;
+
+export async function discoverJwavroListings(
+  preferences: Preferences,
+  apiKey: string,
+) {
+  const cacheKey = JSON.stringify({
+    budgetMin: preferences.budgetMin,
+    budgetMax: preferences.budgetMax,
+    bedrooms: preferences.bedrooms,
+  });
+  const cached = deckCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) return cached.apartments;
+
+  try {
+    const candidates = (await getCandidates(apiKey))
+      .filter(
+        (candidate) =>
+          candidate.url &&
+          candidate.name &&
+          candidate.price !== null &&
+          candidate.price >= preferences.budgetMin &&
+          candidate.price <= preferences.budgetMax &&
+          matchesBedrooms(candidate.bedrooms, preferences.bedrooms),
+      )
+      .slice(0, 8);
+    const apartments = (
+      await Promise.all(
+        candidates.map((candidate) =>
+          fetchJwavroCard(candidate, preferences),
+        ),
+      )
+    ).filter((apartment): apartment is ApartmentCard => apartment !== null);
+    if (apartments.length > 0) {
+      deckCache.set(cacheKey, {
+        expiresAt: Date.now() + 5 * 60 * 1000,
+        apartments,
+      });
+    }
+    return apartments;
+  } catch {
+    return [];
+  }
+}
+
+async function getCandidates(apiKey: string) {
+  const cached = globalCache.criblistJwavroCandidateCache;
+  if (cached && cached.expiresAt > Date.now()) return cached.candidates;
+
+  const activeRequest = globalCache.criblistJwavroCandidateRequest;
+  if (activeRequest) return activeRequest;
+
+  const request = extractCandidates(apiKey);
+  globalCache.criblistJwavroCandidateRequest = request;
+  try {
+    return await request;
+  } finally {
+    if (globalCache.criblistJwavroCandidateRequest === request) {
+      delete globalCache.criblistJwavroCandidateRequest;
+    }
+  }
+}
+
+async function extractCandidates(apiKey: string) {
+  const response = await requestContext("/web/extract", apiKey, {
+    init: {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        url: INVENTORY_URL,
+        schema: listingSchema(),
+        instructions:
+          "Extract every currently available San Francisco rental shown on this inventory page, up to 20. Use the exact detail-page URL, numeric monthly rent, bedrooms and bathrooms. Preserve image URLs when visible. Do not include navigation or properties outside San Francisco. Do not invent missing values.",
+        factCheck: true,
+        maxPages: 1,
+        maxDepth: 0,
+        maxAgeMs: 5 * 60 * 1000,
+        waitForMs: 300,
+        stopAfterMs: 35_000,
+        timeoutMS: 45_000,
+        tags: ["criblist", "production", "jwavro"],
+      }),
+    },
+    timeoutMs: 48_000,
+    maxAttempts: 1,
+  });
+  const candidates =
+    ExtractListingsResponseSchema.parse(response).data.listings;
+  globalCache.criblistJwavroCandidateCache = {
+    expiresAt: Date.now() + 5 * 60 * 1000,
+    candidates,
+  };
+  return candidates;
+}
+
+async function fetchJwavroCard(
+  candidate: ContextListing,
+  preferences: Preferences,
+) {
+  if (!candidate.url) return null;
+  try {
+    return jwavroCardFromHtml(
+      candidate.url,
+      await fetchPublicHtml(candidate.url, 6_000),
+      candidate,
+      preferences,
+    );
+  } catch {
+    return null;
+  }
+}
+
+export function jwavroCardFromHtml(
+  url: string,
+  html: string,
+  candidate: ContextListing,
+  preferences: Preferences,
+) {
+  const listing = jsonLdFromHtml(html).find(
+    (entry) => entry["@type"] === "Apartment" && isRecord(entry.offers),
+  );
+  if (!listing) return null;
+  const offer = listing.offers as Record<string, unknown>;
+  const price =
+    typeof offer.price === "number" ? offer.price : candidate.price;
+  const bedrooms =
+    typeof listing.numberOfBedrooms === "number"
+      ? listing.numberOfBedrooms
+      : candidate.bedrooms;
+  if (
+    price === null ||
+    bedrooms === null ||
+    !matchesBedrooms(bedrooms, preferences.bedrooms)
+  ) {
+    return null;
+  }
+
+  const description =
+    typeof listing.description === "string"
+      ? listing.description.replaceAll("&nbsp;", " ")
+      : candidate.name ?? "San Francisco apartment";
+  const pageText = `${textFromHtml(html)}\n${description}`;
+  const amenities = amenityNames(listing.amenityFeature);
+  const laundry = inferLaundry(pageText);
+  const images = cleanImageUrls([
+    ...imageValues(listing.image),
+    ...candidate.images,
+  ]);
+  const squareFeet = floorSize(listing.floorSize);
+  const availability =
+    typeof offer.availability === "string" &&
+    /InStock|LimitedAvailability/i.test(offer.availability)
+      ? "Available now"
+      : null;
+  const name =
+    typeof listing.name === "string"
+      ? listing.name
+      : candidate.name ?? "San Francisco apartment";
+
+  return createApartmentCard(
+    { url, title: name, description },
+    {
+      name,
+      address: formatPostalAddress(listing.address) ?? candidate.address,
+      neighborhood: candidate.neighborhood,
+      price,
+      bedrooms,
+      bathrooms:
+        typeof listing.numberOfBathroomsTotal === "number"
+          ? listing.numberOfBathroomsTotal
+          : candidate.bathrooms,
+      squareFeet,
+      availability,
+      laundry,
+      dishwasher: /dishwasher/i.test(pageText) ? true : null,
+      petsAllowed: /\bno pets?\b/i.test(pageText)
+        ? false
+        : /\bpet friendly|pets? (?:welcome|allowed)\b/i.test(pageText)
+          ? true
+          : candidate.petsAllowed,
+      amenities: [
+        ...amenities,
+        ...(laundry === "in-unit"
+          ? ["In-unit laundry"]
+          : laundry === "in-building"
+            ? ["Laundry in building"]
+            : []),
+      ],
+      description,
+      caveats: [
+        "Live J. Wavro inventory. Verify availability before applying.",
+      ],
+    },
+    images,
+    preferences,
+  );
+}
+
+function listingSchema() {
+  return {
+    type: "object",
+    properties: {
+      listings: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            name: { type: ["string", "null"] },
+            url: { type: ["string", "null"] },
+            price: { type: ["number", "null"] },
+            bedrooms: { type: ["number", "null"] },
+            bathrooms: { type: ["number", "null"] },
+            neighborhood: { type: ["string", "null"] },
+            address: { type: ["string", "null"] },
+            squareFeet: { type: ["number", "null"] },
+            petsAllowed: { type: ["boolean", "null"] },
+            images: { type: "array", items: { type: "string" } },
+          },
+          required: [
+            "name",
+            "url",
+            "price",
+            "bedrooms",
+            "bathrooms",
+            "neighborhood",
+            "address",
+            "squareFeet",
+            "petsAllowed",
+            "images",
+          ],
+          additionalProperties: false,
+        },
+      },
+    },
+    required: ["listings"],
+    additionalProperties: false,
+  };
+}
+
+function imageValues(value: unknown) {
+  if (typeof value === "string") return [value];
+  return Array.isArray(value)
+    ? value.filter((image): image is string => typeof image === "string")
+    : [];
+}
+
+function amenityNames(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((amenity) =>
+    isRecord(amenity) && typeof amenity.name === "string"
+      ? [amenity.name]
+      : [],
+  );
+}
+
+function floorSize(value: unknown) {
+  if (typeof value === "number") return value;
+  if (!isRecord(value)) return null;
+  return typeof value.value === "number" ? value.value : null;
+}
+
+function inferLaundry(text: string) {
+  if (/in-unit washer|washer\/dryer in unit|in unit laundry/i.test(text)) {
+    return "in-unit" as const;
+  }
+  if (/laundry in building|shared laundry|laundry facilities/i.test(text)) {
+    return "in-building" as const;
+  }
+  return /\bno laundry\b/i.test(text)
+    ? ("none" as const)
+    : ("unknown" as const);
+}

--- a/server/search/ranking.ts
+++ b/server/search/ranking.ts
@@ -51,7 +51,13 @@ export function rankApartments(
   const coreMatches = apartments.filter((apartment) =>
     passesCoreGate(apartment, preferences),
   );
-  const pool = qualityMatches.length > 0 ? qualityMatches : coreMatches;
+  const strict = hasStrictPreferences(preferences);
+  const pool =
+    qualityMatches.length > 0
+      ? qualityMatches
+      : strict
+        ? []
+        : coreMatches;
   const ranked = pool
     .map((apartment) => ({
       ...apartment,
@@ -63,16 +69,25 @@ export function rankApartments(
     apartments: diversifyApartments(ranked).slice(0, 8),
     qualityMatches: qualityMatches.length,
     coreMatches: coreMatches.length,
-    relaxed: qualityMatches.length === 0 && coreMatches.length > 0,
+    relaxed:
+      !strict && qualityMatches.length === 0 && coreMatches.length > 0,
   };
 }
 
 export function dedupeApartments(apartments: ApartmentCard[]) {
-  const seen = new Set<string>();
+  const seenUrls = new Set<string>();
+  const seenListings = new Set<string>();
   return apartments.filter((apartment) => {
-    const key = normalizeListingUrl(apartment.url) ?? apartment.url;
-    if (seen.has(key)) return false;
-    seen.add(key);
+    const urlKey = normalizeListingUrl(apartment.url) ?? apartment.url;
+    const listingKey = listingFingerprint(apartment);
+    if (
+      seenUrls.has(urlKey) ||
+      (listingKey !== null && seenListings.has(listingKey))
+    ) {
+      return false;
+    }
+    seenUrls.add(urlKey);
+    if (listingKey !== null) seenListings.add(listingKey);
     return true;
   });
 }
@@ -135,7 +150,11 @@ export function cleanImageUrls(urls: string[]) {
       const url = new URL(rawUrl);
       const normalized = url.toString();
       if (!url.protocol.startsWith("http") || seen.has(normalized)) return false;
-      if (/(logo|icon|avatar|favicon|sprite|badge|pixel|tracking|map)/i.test(normalized)) {
+      if (
+        /(logo|icon|avatar|favicon|sprite|badge|pixel|tracking|map|coming[_-]?soon|no[_-]?photo)/i.test(
+          normalized,
+        )
+      ) {
         return false;
       }
       seen.add(normalized);
@@ -218,10 +237,12 @@ function passesQualityGate(
   if (apartment.bathrooms === null && preferences.bathroomsMin > 1) return false;
   if (
     preferences.neighborhoods.length > 0 &&
-    apartment.neighborhood &&
-    !preferences.neighborhoods.some((neighborhood) =>
-      apartment.neighborhood?.toLowerCase().includes(neighborhood.toLowerCase()),
-    )
+    (!apartment.neighborhood ||
+      !preferences.neighborhoods.some((neighborhood) =>
+        apartment.neighborhood
+          ?.toLowerCase()
+          .includes(neighborhood.toLowerCase()),
+      ))
   ) {
     return false;
   }
@@ -245,6 +266,17 @@ function passesQualityGate(
   if (preferences.dishwasher && apartment.dishwasher !== true) return false;
   if (preferences.pets && apartment.petsAllowed !== true) return false;
   return true;
+}
+
+function hasStrictPreferences(preferences: Preferences) {
+  return (
+    preferences.bathroomsMin > 1 ||
+    preferences.neighborhoods.length > 0 ||
+    preferences.laundry !== "any" ||
+    preferences.dishwasher ||
+    preferences.pets ||
+    preferences.minSquareFeet > 0
+  );
 }
 
 function passesCoreGate(apartment: ApartmentCard, preferences: Preferences) {
@@ -319,4 +351,19 @@ function normalizeListingUrl(rawUrl: string) {
   } catch {
     return null;
   }
+}
+
+function listingFingerprint(apartment: ApartmentCard) {
+  if (!apartment.address || apartment.price === null) return null;
+  const address = apartment.address
+    .toLowerCase()
+    .replace(/\b(?:apt|apartment|unit|#)\s*[\w-]+\b/g, "")
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim();
+  return [
+    apartment.provider ?? "unknown",
+    address,
+    apartment.price,
+    apartment.bedrooms ?? "unknown",
+  ].join("|");
 }

--- a/server/search/rentbt.ts
+++ b/server/search/rentbt.ts
@@ -1,0 +1,204 @@
+import { createApartmentCard, matchesBedrooms } from "./ranking";
+import type { ApartmentCard, Preferences } from "./schemas";
+
+const ALGOLIA_APP_ID = "R132TNFQIJ";
+const ALGOLIA_SEARCH_KEY = "26692e052b7a312a8f25b8d158606ae1";
+const ALGOLIA_INDEX = "bricktimber_byvyxl_units";
+const ALGOLIA_URL = `https://${ALGOLIA_APP_ID}-dsn.algolia.net/1/indexes/${ALGOLIA_INDEX}/query`;
+
+const globalCache = globalThis as typeof globalThis & {
+  criblistRentBtCache?: Map<
+    string,
+    { expiresAt: number; apartments: ApartmentCard[] }
+  >;
+};
+const rentBtCache = globalCache.criblistRentBtCache ?? new Map();
+globalCache.criblistRentBtCache = rentBtCache;
+
+type RentBtPhoto = {
+  full_url?: unknown;
+  reference_url?: unknown;
+};
+
+type RentBtHit = {
+  permalink?: unknown;
+  propertyName?: unknown;
+  propertyAddress?: unknown;
+  propertyDescription?: unknown;
+  propertyCity?: unknown;
+  unitNumber?: unknown;
+  unitAvailable?: unknown;
+  unitAvailableDate?: unknown;
+  unitBedrooms?: unknown;
+  unitBathrooms?: unknown;
+  unitPrice?: unknown;
+  unitInteriorSquareFeet?: unknown;
+  unitPhotos?: unknown;
+  amenityNames?: unknown;
+  customFacets?: unknown;
+};
+
+export async function discoverRentBtListings(preferences: Preferences) {
+  const cacheKey = JSON.stringify({
+    budgetMin: preferences.budgetMin,
+    budgetMax: preferences.budgetMax,
+    bedrooms: preferences.bedrooms,
+  });
+  const cached = rentBtCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) return cached.apartments;
+
+  try {
+    const response = await fetch(ALGOLIA_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-algolia-application-id": ALGOLIA_APP_ID,
+        "x-algolia-api-key": ALGOLIA_SEARCH_KEY,
+      },
+      body: JSON.stringify({
+        query: "san francisco",
+        hitsPerPage: 30,
+        filters: [
+          "unitAvailable:true",
+          bedroomFilter(preferences.bedrooms),
+          `unitPrice >= ${preferences.budgetMin}`,
+          `unitPrice <= ${preferences.budgetMax}`,
+        ].join(" AND "),
+      }),
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!response.ok) throw new Error(`Brick + Timber returned ${response.status}.`);
+    const result = (await response.json()) as { hits?: unknown };
+    const apartments = Array.isArray(result.hits)
+      ? result.hits.flatMap((hit) =>
+          rentBtCardFromHit(hit as RentBtHit, preferences),
+        )
+      : [];
+    if (apartments.length > 0) {
+      rentBtCache.set(cacheKey, {
+        expiresAt: Date.now() + 2 * 60 * 1000,
+        apartments,
+      });
+    }
+    return apartments;
+  } catch {
+    return [];
+  }
+}
+
+export function rentBtCardFromHit(
+  hit: RentBtHit,
+  preferences: Preferences,
+) {
+  if (
+    typeof hit.permalink !== "string" ||
+    typeof hit.propertyName !== "string" ||
+    typeof hit.unitBedrooms !== "number" ||
+    typeof hit.unitPrice !== "number" ||
+    hit.unitAvailable !== true ||
+    hit.propertyCity !== "San Francisco" ||
+    !matchesBedrooms(hit.unitBedrooms, preferences.bedrooms)
+  ) {
+    return [];
+  }
+
+  const amenities = Array.isArray(hit.amenityNames)
+    ? hit.amenityNames.filter(
+        (amenity): amenity is string => typeof amenity === "string",
+      )
+    : [];
+  const images = Array.isArray(hit.unitPhotos)
+    ? hit.unitPhotos.flatMap((photo) => {
+        if (typeof photo !== "object" || photo === null) return [];
+        const value = photo as RentBtPhoto;
+        if (typeof value.full_url === "string") return [value.full_url];
+        return typeof value.reference_url === "string"
+          ? [value.reference_url]
+          : [];
+      })
+    : [];
+  const neighborhood =
+    typeof hit.customFacets === "object" &&
+    hit.customFacets !== null &&
+    typeof (hit.customFacets as { neighborhood?: unknown }).neighborhood ===
+      "string"
+      ? (hit.customFacets as { neighborhood: string }).neighborhood
+      : null;
+  const description =
+    typeof hit.propertyDescription === "string"
+      ? hit.propertyDescription
+      : hit.propertyName;
+  const laundry = inferLaundry(amenities);
+
+  return [
+    createApartmentCard(
+      {
+        url: hit.permalink,
+        title: apartmentName(hit.propertyName, hit.unitNumber),
+        description,
+      },
+      {
+        name: apartmentName(hit.propertyName, hit.unitNumber),
+        address:
+          typeof hit.propertyAddress === "string"
+            ? hit.propertyAddress
+            : null,
+        neighborhood,
+        price: hit.unitPrice,
+        bedrooms: hit.unitBedrooms,
+        bathrooms:
+          typeof hit.unitBathrooms === "number" ? hit.unitBathrooms : null,
+        squareFeet:
+          typeof hit.unitInteriorSquareFeet === "number"
+            ? hit.unitInteriorSquareFeet
+            : null,
+        availability:
+          typeof hit.unitAvailableDate === "string"
+            ? hit.unitAvailableDate
+            : "Available now",
+        laundry,
+        dishwasher: includesAmenity(amenities, "dishwasher") ? true : null,
+        petsAllowed: includesAmenity(amenities, "pet friendly") ? true : null,
+        amenities,
+        description,
+        caveats: [
+          "Live Brick + Timber inventory. Verify availability before applying.",
+        ],
+      },
+      images,
+      preferences,
+    ),
+  ];
+}
+
+function bedroomFilter(bedrooms: Preferences["bedrooms"]) {
+  if (bedrooms === "studio") return "unitBedrooms = 0";
+  if (bedrooms === "3+") return "unitBedrooms >= 3";
+  return `unitBedrooms = ${bedrooms}`;
+}
+
+function apartmentName(propertyName: string, unitNumber: unknown) {
+  return typeof unitNumber === "string" && unitNumber.trim()
+    ? `${propertyName} #${unitNumber}`
+    : propertyName;
+}
+
+function includesAmenity(amenities: string[], value: string) {
+  return amenities.some((amenity) =>
+    amenity.toLowerCase().includes(value.toLowerCase()),
+  );
+}
+
+function inferLaundry(amenities: string[]) {
+  if (
+    amenities.some((amenity) =>
+      /in-unit|in unit|washer\/dryer in unit/i.test(amenity),
+    )
+  ) {
+    return "in-unit" as const;
+  }
+  if (amenities.some((amenity) => /laundry/i.test(amenity))) {
+    return "in-building" as const;
+  }
+  return "unknown" as const;
+}

--- a/server/search/rentsfnow.ts
+++ b/server/search/rentsfnow.ts
@@ -1,0 +1,219 @@
+import {
+  decodeHtml,
+  fetchPublicHtml,
+  metaContent,
+  textFromHtml,
+} from "./html";
+import {
+  cleanImageUrls,
+  createApartmentCard,
+  matchesBedrooms,
+} from "./ranking";
+import type { ApartmentCard, Preferences } from "./schemas";
+
+const INVENTORY_URL = "https://www.rentsfnow.com/";
+
+const globalCache = globalThis as typeof globalThis & {
+  criblistRentSfNowCache?: Map<
+    string,
+    { expiresAt: number; apartments: ApartmentCard[] }
+  >;
+};
+const rentSfNowCache = globalCache.criblistRentSfNowCache ?? new Map();
+globalCache.criblistRentSfNowCache = rentSfNowCache;
+
+type RentSfNowCandidate = {
+  url: string;
+  name: string;
+  neighborhood: string;
+  price: number;
+  bedrooms: number;
+  bathrooms: number;
+  image: string;
+};
+
+export async function discoverRentSfNowListings(preferences: Preferences) {
+  const cacheKey = JSON.stringify({
+    budgetMin: preferences.budgetMin,
+    budgetMax: preferences.budgetMax,
+    bedrooms: preferences.bedrooms,
+  });
+  const cached = rentSfNowCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) return cached.apartments;
+
+  try {
+    const html = await fetchPublicHtml(INVENTORY_URL, 6_000);
+    const candidates = extractRentSfNowCandidates(html)
+      .filter(
+        (candidate) =>
+          candidate.price >= preferences.budgetMin &&
+          candidate.price <= preferences.budgetMax &&
+          matchesBedrooms(candidate.bedrooms, preferences.bedrooms),
+      )
+      .slice(0, 6);
+    const apartments = (
+      await Promise.all(
+        candidates.map((candidate) =>
+          enrichRentSfNowCandidate(candidate, preferences),
+        ),
+      )
+    ).filter((apartment): apartment is ApartmentCard => apartment !== null);
+    if (apartments.length > 0) {
+      rentSfNowCache.set(cacheKey, {
+        expiresAt: Date.now() + 3 * 60 * 1000,
+        apartments,
+      });
+    }
+    return apartments;
+  } catch {
+    return [];
+  }
+}
+
+export function extractRentSfNowCandidates(html: string) {
+  return [
+    ...html.matchAll(
+      /<a href="([^"]+)" class="apartment-image"[^>]*>[\s\S]*?background-image:url\(['"]?([^'")]+)['"]?\)[^>]*>[\s\S]*?<h5>([\s\S]*?)<\/h5>\s*<h4>([\s\S]*?)<\/h4>\s*<p>([\s\S]*?)<\/p>/gi,
+    ),
+  ].flatMap((match): RentSfNowCandidate[] => {
+    const details = decodeHtml(match[5]).replace(/<[^>]+>/g, " ");
+    const price = Number(
+      details.match(/\$([\d,]+)/)?.[1]?.replaceAll(",", "") ?? NaN,
+    );
+    const bedrooms = /studio/i.test(details)
+      ? 0
+      : Number(details.match(/(\d+)\s*beds?/i)?.[1] ?? NaN);
+    const bathrooms = Number(
+      details.match(/(\d+(?:\.\d+)?)\s*baths?/i)?.[1] ?? NaN,
+    );
+    if (
+      !Number.isFinite(price) ||
+      !Number.isFinite(bedrooms) ||
+      !Number.isFinite(bathrooms)
+    ) {
+      return [];
+    }
+    return [
+      {
+        url: new URL(match[1], INVENTORY_URL).toString(),
+        image: new URL(decodeHtml(match[2]), INVENTORY_URL).toString(),
+        neighborhood: decodeHtml(match[3]).replace(/<[^>]+>/g, "").trim(),
+        name: decodeHtml(match[4]).replace(/<[^>]+>/g, "").trim(),
+        price,
+        bedrooms,
+        bathrooms,
+      },
+    ];
+  });
+}
+
+async function enrichRentSfNowCandidate(
+  candidate: RentSfNowCandidate,
+  preferences: Preferences,
+) {
+  try {
+    const html = await fetchPublicHtml(candidate.url, 5_000);
+    const text = textFromHtml(html);
+    const images = cleanImageUrls([
+      candidate.image,
+      ...(html.match(
+        /https:\/\/cdn\.rentcafe\.com\/[^"'<>]+?\.(?:jpg|jpeg|png|webp)/gi,
+      ) ?? []),
+    ]);
+    const squareFeetText = text.match(
+      /\b([\d,]+)\s*(?:sq\.?\s*ft|sqft|square feet)\b/i,
+    )?.[1];
+    const laundry = inferLaundry(text);
+    const amenities = inferAmenities(text, laundry);
+    const description = decodeHtml(
+      metaContent(html, "description") ?? candidate.name,
+    );
+    return createApartmentCard(
+      {
+        url: candidate.url,
+        title: candidate.name,
+        description,
+      },
+      {
+        name: candidate.name,
+        address: `${candidate.name.replace(/\s+#.+$/, "")}, San Francisco, CA`,
+        neighborhood: candidate.neighborhood,
+        price: candidate.price,
+        bedrooms: candidate.bedrooms,
+        bathrooms: candidate.bathrooms,
+        squareFeet: squareFeetText
+          ? Number(squareFeetText.replaceAll(",", ""))
+          : null,
+        availability: "Available now",
+        laundry,
+        dishwasher: /dishwasher/i.test(text) ? true : null,
+        petsAllowed: /pet friendly|pets? (?:welcome|allowed)/i.test(text)
+          ? true
+          : null,
+        amenities,
+        description,
+        caveats: [
+          "Live RentSFNow inventory. Verify availability before applying.",
+        ],
+      },
+      images,
+      preferences,
+    );
+  } catch {
+    return createApartmentCard(
+      {
+        url: candidate.url,
+        title: candidate.name,
+        description: candidate.name,
+      },
+      {
+        name: candidate.name,
+        address: null,
+        neighborhood: candidate.neighborhood,
+        price: candidate.price,
+        bedrooms: candidate.bedrooms,
+        bathrooms: candidate.bathrooms,
+        squareFeet: null,
+        availability: "Available now",
+        laundry: "unknown",
+        dishwasher: null,
+        petsAllowed: null,
+        amenities: [],
+        description: candidate.name,
+        caveats: [
+          "Live RentSFNow inventory. Verify availability before applying.",
+        ],
+      },
+      [candidate.image],
+      preferences,
+    );
+  }
+}
+
+function inferLaundry(text: string) {
+  if (/in-unit washer|washer\/dryer in unit|in unit laundry/i.test(text)) {
+    return "in-unit" as const;
+  }
+  if (/laundry facilities|laundry in building|shared laundry/i.test(text)) {
+    return "in-building" as const;
+  }
+  return "unknown" as const;
+}
+
+function inferAmenities(
+  text: string,
+  laundry: "in-unit" | "in-building" | "unknown",
+) {
+  return [
+    /dishwasher/i.test(text) ? "Dishwasher" : null,
+    /elevator/i.test(text) ? "Elevator" : null,
+    /pet friendly|pets? (?:welcome|allowed)/i.test(text)
+      ? "Pet friendly"
+      : null,
+    /roof(?:top)? deck|patio|yard|courtyard|balcony/i.test(text)
+      ? "Outdoor space"
+      : null,
+    laundry === "in-unit" ? "In-unit laundry" : null,
+    laundry === "in-building" ? "Laundry in building" : null,
+  ].filter((amenity): amenity is string => Boolean(amenity));
+}

--- a/server/search/schemas.ts
+++ b/server/search/schemas.ts
@@ -15,7 +15,7 @@ export const PreferencesSchema = z.object({
   minSquareFeet: z.number().min(0).max(5000),
 });
 
-export const MarkdownResponseSchema = z.object({
+export const ListingSnapshotSchema = z.object({
   success: z.literal(true),
   markdown: z.string(),
   contentLength: z.number(),
@@ -34,6 +34,28 @@ export const MarkdownResponseSchema = z.object({
 export const HtmlResponseSchema = z
   .object({
     html: z.string(),
+  })
+  .passthrough();
+
+export const ContextListingSchema = z.object({
+  name: z.string().nullable(),
+  url: z.string().nullable(),
+  price: z.number().nullable(),
+  bedrooms: z.number().nullable(),
+  bathrooms: z.number().nullable(),
+  neighborhood: z.string().nullable(),
+  address: z.string().nullable(),
+  squareFeet: z.number().nullable(),
+  petsAllowed: z.boolean().nullable(),
+  images: z.array(z.string()),
+});
+
+export const ExtractListingsResponseSchema = z
+  .object({
+    status: z.string(),
+    data: z.object({
+      listings: z.array(ContextListingSchema),
+    }),
   })
   .passthrough();
 
@@ -63,7 +85,8 @@ export const ApartmentCardSchema = z.object({
 
 export type Preferences = z.infer<typeof PreferencesSchema>;
 export type ApartmentCard = z.infer<typeof ApartmentCardSchema>;
-export type MarkdownSnapshot = z.infer<typeof MarkdownResponseSchema>;
+export type ListingSnapshot = z.infer<typeof ListingSnapshotSchema>;
+export type ContextListing = z.infer<typeof ContextListingSchema>;
 
 export type ExtractedApartment = {
   name: string | null;

--- a/server/search/service.ts
+++ b/server/search/service.ts
@@ -1,27 +1,42 @@
 import { discoverCraigslistListings } from "./craigslist";
+import { discoverJwavroListings } from "./jwavro";
 import { discoverMosserListings } from "./mosser";
 import { countByProvider, dedupeApartments, rankApartments } from "./ranking";
-import type { Preferences } from "./schemas";
+import { discoverRentBtListings } from "./rentbt";
+import { discoverRentSfNowListings } from "./rentsfnow";
+import type { ApartmentCard, Preferences } from "./schemas";
+
+export type SearchSource =
+  | "all"
+  | "fast"
+  | "independent"
+  | "craigslist"
+  | "extract";
+
+type SourceId =
+  | "brick-timber"
+  | "rentsfnow"
+  | "mosser"
+  | "craigslist"
+  | "jwavro";
 
 export async function searchApartments(
   preferences: Preferences,
   apiKey: string,
-  source: "all" | "independent" | "craigslist" = "all",
+  source: SearchSource = "all",
 ) {
   const startedAt = Date.now();
-  const [craigslistResult, localResult] = await Promise.all([
-    source === "independent"
-      ? emptyMeasurement()
-      : measure(() => discoverCraigslistListings(preferences, apiKey)),
-    source === "craigslist"
-      ? emptyMeasurement()
-      : measure(() => discoverMosserListings(preferences)),
-  ]);
+  const sources = selectedSources(source);
+  const measurements = await Promise.all(
+    sources.map(async (sourceId) => ({
+      sourceId,
+      ...(await measure(() => runSource(sourceId, preferences, apiKey))),
+    })),
+  );
   const discoveredAt = Date.now();
-  const discoveredApartments = dedupeApartments([
-    ...localResult.value,
-    ...craigslistResult.value,
-  ]);
+  const discoveredApartments = dedupeApartments(
+    measurements.flatMap((measurement) => measurement.value),
+  );
   const ranked = rankApartments(discoveredApartments, preferences);
 
   return {
@@ -30,13 +45,16 @@ export async function searchApartments(
     timings: {
       discoveryMs: discoveredAt - startedAt,
       totalMs: Date.now() - startedAt,
-      sources: {
-        craigslistMs: craigslistResult.durationMs,
-        independentMs: localResult.durationMs,
-      },
+      sources: Object.fromEntries(
+        measurements.map((measurement) => [
+          measurement.sourceId,
+          measurement.durationMs,
+        ]),
+      ),
     },
     diagnostics: {
-      source: "live-local-aggregate",
+      source: "live-multi-source-aggregate",
+      requestedLane: source,
       extracted: discoveredApartments.length,
       discoveredSources: countByProvider(discoveredApartments),
       deckSources: countByProvider(ranked.apartments),
@@ -47,8 +65,28 @@ export async function searchApartments(
   };
 }
 
-function emptyMeasurement() {
-  return Promise.resolve({ value: [], durationMs: 0 });
+function selectedSources(source: SearchSource): SourceId[] {
+  if (source === "fast") return ["brick-timber", "rentsfnow", "mosser"];
+  if (source === "craigslist") return ["craigslist"];
+  if (source === "extract") return ["jwavro"];
+  if (source === "independent") {
+    return ["brick-timber", "rentsfnow", "mosser", "jwavro"];
+  }
+  return ["brick-timber", "rentsfnow", "mosser", "craigslist", "jwavro"];
+}
+
+function runSource(
+  source: SourceId,
+  preferences: Preferences,
+  apiKey: string,
+): Promise<ApartmentCard[]> {
+  if (source === "brick-timber") return discoverRentBtListings(preferences);
+  if (source === "rentsfnow") return discoverRentSfNowListings(preferences);
+  if (source === "mosser") return discoverMosserListings(preferences);
+  if (source === "craigslist") {
+    return discoverCraigslistListings(preferences, apiKey);
+  }
+  return discoverJwavroListings(preferences, apiKey);
 }
 
 async function measure<T>(operation: () => Promise<T>) {

--- a/shared/providers.ts
+++ b/shared/providers.ts
@@ -1,0 +1,51 @@
+export const LISTING_PROVIDERS = [
+  {
+    domain: "craigslist.org",
+    label: "craigslist",
+    url: "https://sfbay.craigslist.org/search/sfc/apa",
+  },
+  {
+    domain: "rentbt.com",
+    label: "brick + timber",
+    url: "https://rentbt.com/listings/",
+  },
+  {
+    domain: "rentsfnow.com",
+    label: "rentsfnow",
+    url: "https://www.rentsfnow.com/",
+    fallbackLookup: {
+      type: "by_name",
+      name: "RentSFNow",
+    },
+  },
+  {
+    domain: "mosserliving.com",
+    label: "mosser",
+    url: "https://www.mosserliving.com/san-francisco-apartments/",
+  },
+  {
+    domain: "jwavro.com",
+    label: "j. wavro",
+    url: "https://www.jwavro.com/rental_list.php?hood=sfc",
+  },
+] as const;
+
+export type ProviderBrand = {
+  domain: string;
+  label: string;
+  url: string;
+  title: string;
+  logoUrl: string | null;
+  color: string | null;
+};
+
+export function fallbackProviderBrands(): ProviderBrand[] {
+  return LISTING_PROVIDERS.map((provider) => ({
+    domain: provider.domain,
+    label: provider.label,
+    url: provider.url,
+    title: provider.label,
+    logoUrl: null,
+    color: null,
+  }));
+}

--- a/tests/search-sources.test.ts
+++ b/tests/search-sources.test.ts
@@ -1,0 +1,291 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { selectPreferredBrandLogo } from "../server/brand/providers";
+import {
+  cardFromSnapshot,
+  extractCraigslistSearchCandidates,
+  snapshotFromHtml,
+} from "../server/search/craigslist";
+import { fetchPublicHtml } from "../server/search/html";
+import { jwavroCardFromHtml } from "../server/search/jwavro";
+import { rankApartments } from "../server/search/ranking";
+import { rentBtCardFromHit } from "../server/search/rentbt";
+import { extractRentSfNowCandidates } from "../server/search/rentsfnow";
+import type {
+  ApartmentCard,
+  ContextListing,
+  Preferences,
+} from "../server/search/schemas";
+
+const preferences: Preferences = {
+  budgetMin: 1_800,
+  budgetMax: 3_500,
+  bedrooms: "1",
+  bathroomsMin: 1,
+  neighborhoods: [],
+  moveIn: "30 days",
+  laundry: "any",
+  dishwasher: false,
+  pets: false,
+  minSquareFeet: 0,
+};
+
+test("prefers a square brand icon over a larger wordmark", () => {
+  const selected = selectPreferredBrandLogo([
+    {
+      url: "https://media.brand.dev/rentsfnow-wordmark.png",
+      type: "logo",
+      mode: "has_opaque_background",
+      resolution: { width: 975, height: 512, aspect_ratio: 1.9 },
+    },
+    {
+      url: "https://media.brand.dev/rentsfnow-icon.png",
+      type: "icon",
+      mode: "light",
+      resolution: { width: 152, height: 152, aspect_ratio: 1 },
+    },
+  ]);
+
+  assert.equal(selected, "https://media.brand.dev/rentsfnow-icon.png");
+});
+
+test("parses current Craigslist search result markup", () => {
+  const candidates = extractCraigslistSearchCandidates(`
+    <li class="cl-static-search-result" title="Sunny one bedroom">
+      <a href="https://www.craigslist.org/view/d/san-francisco-sunny-one/abc123">
+        <div class="title">Sunny one bedroom</div>
+        <div class="details">
+          <div class="price">$2,750</div>
+          <div class="location">mission</div>
+        </div>
+      </a>
+    </li>
+  `);
+
+  assert.deepEqual(candidates, [
+    {
+      url: "https://www.craigslist.org/view/d/san-francisco-sunny-one/abc123",
+      name: "Sunny one bedroom",
+      price: 2_750,
+      location: "mission",
+    },
+  ]);
+});
+
+test("accepts Craigslist House JSON-LD and builds a complete card", () => {
+  const url =
+    "https://www.craigslist.org/view/d/san-francisco-sunny-one/abc123";
+  const html = `
+    <html>
+      <head>
+        <title>$2,750 / 1br - Sunny one bedroom</title>
+        <meta name="description" content="Sunny home with shared laundry and dishwasher">
+        <meta property="og:image" content="https://images.craigslist.org/example_600x450.jpg">
+        <link rel="canonical" href="${url}">
+        <script type="application/ld+json">
+          {
+            "@type": "House",
+            "numberOfBathroomsTotal": 1,
+            "petsAllowed": true,
+            "address": {
+              "@type": "PostalAddress",
+              "streetAddress": "123 Valencia Street",
+              "addressLocality": "San Francisco",
+              "addressRegion": "CA",
+              "postalCode": "94110"
+            }
+          }
+        </script>
+      </head>
+      <body>
+        <h1 class="postingtitle">
+          <span class="price">$2,750</span>
+          <span class="housing">/ 1br - </span>
+          <span id="titletextonly">Sunny one bedroom</span>
+        </h1>
+        available now
+        shared laundry
+        dishwasher
+        <img src="https://images.craigslist.org/example_600x450.jpg">
+      </body>
+    </html>
+  `;
+  const card = cardFromSnapshot(
+    snapshotFromHtml(url, html),
+    preferences,
+  );
+
+  assert.ok(card);
+  assert.equal(card.provider, "craigslist.org");
+  assert.equal(card.price, 2_750);
+  assert.equal(card.bedrooms, 1);
+  assert.equal(card.bathrooms, 1);
+  assert.equal(card.address, "123 Valencia Street, San Francisco, CA, 94110");
+  assert.equal(card.laundry, "in-building");
+  assert.equal(card.images.length, 1);
+});
+
+test("parses RentSFNow featured inventory cards", () => {
+  const candidates = extractRentSfNowCandidates(`
+    <a href="/apartments/rental/655-powell-5" class="apartment-image">
+      <div class="veritasCarouselImage" style="background-image:url('https://cdn.rentcafe.com/unit.jpg');"></div>
+      <h5>Nob Hill</h5>
+      <h4>655 Powell #5</h4>
+      <p>1 Bed \\\\ 1 Bath \\\\ &#36;3,495</p>
+    </a>
+  `);
+
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0].price, 3_495);
+  assert.equal(candidates[0].bedrooms, 1);
+  assert.equal(candidates[0].bathrooms, 1);
+  assert.equal(candidates[0].neighborhood, "Nob Hill");
+});
+
+test("maps available Brick + Timber hits without a detail scrape", () => {
+  const cards = rentBtCardFromHit(
+    {
+      permalink: "https://rentbt.com/listing/540-leavenworth-unit-104",
+      propertyName: "540 Leavenworth Street",
+      propertyAddress: "540 Leavenworth Street, San Francisco, CA 94109",
+      propertyDescription: "Pet friendly with common area laundry.",
+      propertyCity: "San Francisco",
+      unitNumber: "104",
+      unitAvailable: true,
+      unitBedrooms: 1,
+      unitBathrooms: 1,
+      unitPrice: 2_595,
+      unitInteriorSquareFeet: 610,
+      unitPhotos: [
+        { full_url: "https://dam.getresi.co/540-leavenworth-full.jpg" },
+      ],
+      amenityNames: ["Pet Friendly", "Common Area Laundry"],
+      customFacets: { neighborhood: "Tenderloin" },
+    },
+    preferences,
+  );
+
+  assert.equal(cards.length, 1);
+  assert.equal(cards[0].provider, "rentbt.com");
+  assert.equal(cards[0].squareFeet, 610);
+  assert.equal(cards[0].petsAllowed, true);
+  assert.equal(cards[0].laundry, "in-building");
+});
+
+test("uses J. Wavro detail JSON-LD to enrich Extract candidates", () => {
+  const candidate: ContextListing = {
+    name: "Remodeled Junior One Bedroom",
+    url: "https://www.jwavro.com/rental_details.php?id=1",
+    price: 3_000,
+    bedrooms: 1,
+    bathrooms: 1,
+    neighborhood: "Richmond",
+    address: null,
+    squareFeet: null,
+    petsAllowed: null,
+    images: [],
+  };
+  const html = `
+    <script type="application/ld+json">
+      {
+        "@type": "Apartment",
+        "name": "Remodeled Junior One Bedroom",
+        "description": "Shared laundry in building. No pets.",
+        "address": {
+          "@type": "PostalAddress",
+          "streetAddress": "22nd Avenue",
+          "addressLocality": "San Francisco",
+          "addressRegion": "CA"
+        },
+        "numberOfBedrooms": 1,
+        "numberOfBathroomsTotal": 1,
+        "image": ["https://static.letsrent.com/apartment.png"],
+        "offers": {
+          "@type": "Offer",
+          "price": 3000,
+          "availability": "https://schema.org/InStock"
+        }
+      }
+    </script>
+  `;
+  const card = jwavroCardFromHtml(
+    candidate.url!,
+    html,
+    candidate,
+    preferences,
+  );
+
+  assert.ok(card);
+  assert.equal(card.provider, "jwavro.com");
+  assert.equal(card.availability, "Available now");
+  assert.equal(card.laundry, "in-building");
+  assert.equal(card.petsAllowed, false);
+  assert.equal(card.images.length, 1);
+});
+
+test("does not silently relax explicit must-have filters", () => {
+  const apartment: ApartmentCard = {
+    name: "Incomplete one bedroom",
+    url: "https://example.com/listing",
+    provider: "example.com",
+    images: ["https://example.com/listing.jpg"],
+    price: 3_000,
+    bedrooms: 1,
+    bathrooms: 1,
+    neighborhood: null,
+    address: "123 Main Street, San Francisco, CA",
+    squareFeet: null,
+    floorLevel: null,
+    availability: "Available now",
+    description: null,
+    laundry: "unknown",
+    dishwasher: null,
+    petsAllowed: null,
+    amenities: [],
+    matchScore: 80,
+    matchReasons: [],
+    catches: [],
+    preferenceFit: true,
+  };
+  const ranked = rankApartments(
+    [apartment],
+    {
+      ...preferences,
+      neighborhoods: ["Mission"],
+      laundry: "in-unit",
+      dishwasher: true,
+      pets: true,
+      minSquareFeet: 500,
+    },
+  );
+
+  assert.equal(ranked.apartments.length, 0);
+  assert.equal(ranked.relaxed, false);
+});
+
+test("coalesces concurrent requests for the same public page", async () => {
+  const originalFetch = globalThis.fetch;
+  let requests = 0;
+  globalThis.fetch = async () => {
+    requests += 1;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    return new Response("<html>listing</html>", { status: 200 });
+  };
+
+  try {
+    const url = "https://cache-test.invalid/unique-listing";
+    const pages = await Promise.all([
+      fetchPublicHtml(url),
+      fetchPublicHtml(url),
+      fetchPublicHtml(url),
+    ]);
+    assert.deepEqual(pages, [
+      "<html>listing</html>",
+      "<html>listing</html>",
+      "<html>listing</html>",
+    ]);
+    assert.equal(requests, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary

- aggregate live inventory from Craigslist, Brick + Timber, RentSFNow, Mosser, and J. Wavro
- open the deck from fast feeds while deeper Context.dev HTML and Extract requests finish concurrently
- enrich the landing-page source stack through the Context.dev Brand API, including a reliable RentSFNow icon fallback
- enforce strict must-have filters, semantic deduplication, provider diversity, and short-lived request caching
- add source parser tests and a repeatable multi-profile stress harness

## Validation

- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run stress:search` — six profiles, zero request errors